### PR TITLE
Fix to avoid potential ClassCircularityError

### DIFF
--- a/src/main/java/org/valuereporter/agent/TimedClassTransformer.java
+++ b/src/main/java/org/valuereporter/agent/TimedClassTransformer.java
@@ -38,9 +38,12 @@ public class TimedClassTransformer implements ClassFileTransformer {
                             ProtectionDomain protectionDomain, byte[] classBytes) throws IllegalClassFormatException {
         String className = fullyQualifiedClassName.replace("/", ".");
 
+        //class inspection can in some cases lead to ClassCircularityError, so return early if class is not meant to be instrumented
+        // similar issue fixed here: https://github.com/ActiveJpa/activejpa/issues/26
+        if (!isToBeObserved(className)) return null;
+
         classPool.appendClassPath(new ByteArrayClassPath(className, classBytes));
 
-        if (!isToBeObserved(className)) return null;
         try {
             CtClass ctClass = classPool.get(className);
             if (ctClass.isFrozen()) {


### PR DESCRIPTION
Experienced similar issues to the ones found here:
https://github.com/minnal/minnal/issues/116
Calling ctClass.isAnnotation() and ctClass.isInterface() causes ClassCircularityError when applied to files out of our control. As the agent is only meant to instrument certain classes in the first place, we can avoid the issue by returning early if the class is not meant to be processed.

